### PR TITLE
Allow 1.x versions of dogstatsd-ruby

### DIFF
--- a/datadoge.gemspec
+++ b/datadoge.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 0'
 
-  spec.add_runtime_dependency 'dogstatsd-ruby', '~> 0'
+  spec.add_runtime_dependency 'dogstatsd-ruby', "> 0"
   spec.add_runtime_dependency 'gem_config', '~> 0'
 end


### PR DESCRIPTION
As it stands right now, this gem only allows the 0.4 released version of `dogstatsd-ruby`. They have been on 1.x since 2012. 

Everything seems to work as expected with the new dependencies. 
