### PR TITLE
Add configuration for additional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ To enable Datadog reporting in non-production environments, add the following to
       config.environments = ['staging', 'production']
     end
 
+To add additional tags, add the following to the configuration:
+
+    config.tags = ['role:myapp', 'host:myapp-1', 'region:east']
+
+
 ## Contributing
 
 1. Fork it ( https://github.com/metova/datadoge/fork )

--- a/lib/datadoge.rb
+++ b/lib/datadoge.rb
@@ -7,6 +7,7 @@ module Datadoge
 
   with_configuration do
     has :environments, classes: Array, default: ['production']
+    has :tags, classes: Array, default: ["host:#{ENV['INSTRUMENTATION_HOSTNAME']}"]
   end
 
   class Railtie < Rails::Railtie
@@ -19,9 +20,8 @@ module Datadoge
         action = "action:#{event.payload[:action]}"
         format = "format:#{event.payload[:format] || 'all'}"
         format = "format:all" if format == "format:*/*"
-        host = "host:#{ENV['INSTRUMENTATION_HOSTNAME']}"
         status = event.payload[:status]
-        tags = [controller, action, format, host]
+        tags = [controller, action, format] + Datadoge.configuration.tags
         ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags, :measurement => "request.total_duration", :value => event.duration
         ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags,  :measurement => "database.query.time", :value => event.payload[:db_runtime]
         ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags,  :measurement => "web.view.time", :value => event.payload[:view_runtime]


### PR DESCRIPTION
I'd like to be able to configure additional tags so that I can differentiate stats from different sources, for example from different apps, hosts, regions, etc.
