### PR TITLE
Add configuration for customizable metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ To enable Datadog reporting in non-production environments, add the following to
       config.environments = ['staging', 'production']
     end
 
+Override the default metric name with the following configuration:
+
+    config.metric = :rails_performance
+
 ## Contributing
 
 1. Fork it ( https://github.com/metova/datadoge/fork )

--- a/lib/datadoge.rb
+++ b/lib/datadoge.rb
@@ -7,7 +7,7 @@ module Datadoge
 
   with_configuration do
     has :environments, classes: Array, default: ['production']
-    has :metric, classes: [Symbol, String], default: :performance
+    has :metric, classes: [Symbol, String], default: 'Performance'
   end
 
   class Railtie < Rails::Railtie
@@ -39,7 +39,7 @@ module Datadoge
         measurement = payload[:measurement]
         value = payload[:value]
         tags = payload[:tags]
-        key_name = "#{name.to_s.capitalize}.#{measurement}"
+        key_name = "#{name.to_s}.#{measurement}"
         if action == :increment
           $statsd.increment key_name, :tags => tags
         else

--- a/lib/datadoge.rb
+++ b/lib/datadoge.rb
@@ -24,8 +24,8 @@ module Datadoge
         status = event.payload[:status]
         tags = [controller, action, format, host]
         ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags, :measurement => "request.total_duration", :value => event.duration
-        ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags, :measurement => "database.query.time", :value => event.payload[:db_runtime]
-        ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags, :measurement => "web.view.time", :value => event.payload[:view_runtime]
+        ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags,  :measurement => "database.query.time", :value => event.payload[:db_runtime]
+        ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags,  :measurement => "web.view.time", :value => event.payload[:view_runtime]
         ActiveSupport::Notifications.instrument :performance, :tags => tags,  :measurement => "request.status.#{status}"
       end
 

--- a/lib/datadoge.rb
+++ b/lib/datadoge.rb
@@ -23,11 +23,10 @@ module Datadoge
         host = "host:#{ENV['INSTRUMENTATION_HOSTNAME']}"
         status = event.payload[:status]
         tags = [controller, action, format, host]
-        metric = Datadoge.configuration.metric
-        ActiveSupport::Notifications.instrument metric, :action => :timing, :tags => tags, :measurement => "request.total_duration", :value => event.duration
-        ActiveSupport::Notifications.instrument metric, :action => :timing, :tags => tags, :measurement => "database.query.time", :value => event.payload[:db_runtime]
-        ActiveSupport::Notifications.instrument metric, :action => :timing, :tags => tags, :measurement => "web.view.time", :value => event.payload[:view_runtime]
-        ActiveSupport::Notifications.instrument metric, :tags => tags,  :measurement => "request.status.#{status}"
+        ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags, :measurement => "request.total_duration", :value => event.duration
+        ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags, :measurement => "database.query.time", :value => event.payload[:db_runtime]
+        ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags, :measurement => "web.view.time", :value => event.payload[:view_runtime]
+        ActiveSupport::Notifications.instrument :performance, :tags => tags,  :measurement => "request.status.#{status}"
       end
 
       ActiveSupport::Notifications.subscribe /performance/ do |name, start, finish, id, payload|
@@ -39,7 +38,7 @@ module Datadoge
         measurement = payload[:measurement]
         value = payload[:value]
         tags = payload[:tags]
-        key_name = "#{name.to_s}.#{measurement}"
+        key_name = "#{Datadoge.configuration.metric.to_s}.#{measurement}"
         if action == :increment
           $statsd.increment key_name, :tags => tags
         else


### PR DESCRIPTION
I'd like to be able to configure the metric name sent to DataDog so that I can differentiate stats coming from other integrations.
