### PR TITLE
Bump dogstatsd-ruby gem to 2.0.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     datadoge (0.0.3)
-      dogstatsd-ruby (> 0)
+      dogstatsd-ruby (~> 2.0)
       gem_config (~> 0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    dogstatsd-ruby (1.5.0)
+    dogstatsd-ruby (2.0.0)
     gem_config (0.3.1)
     rake (0.9.6)
 
@@ -21,4 +21,4 @@ DEPENDENCIES
   rake (~> 0)
 
 BUNDLED WITH
-   1.10.6
+   1.13.1

--- a/datadoge.gemspec
+++ b/datadoge.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 0'
 
-  spec.add_runtime_dependency 'dogstatsd-ruby', "> 0"
+  spec.add_runtime_dependency 'dogstatsd-ruby', "~> 2.0"
   spec.add_runtime_dependency 'gem_config', '~> 0'
 end

--- a/lib/datadoge.rb
+++ b/lib/datadoge.rb
@@ -1,6 +1,6 @@
 require 'datadoge/version'
 require 'gem_config'
-require 'statsd'
+require 'datadog/statsd'
 
 module Datadoge
   include GemConfig::Base
@@ -11,7 +11,7 @@ module Datadoge
 
   class Railtie < Rails::Railtie
     initializer "datadoge.configure_rails_initialization" do |app|
-      $statsd = Statsd.new
+      $statsd = ::Datadog::Statsd.new
 
       ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)

--- a/lib/datadoge/version.rb
+++ b/lib/datadoge/version.rb
@@ -1,3 +1,3 @@
 module Datadoge
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Instead of 
`require "statsd"` 
we need to use 
`require "datadog/statsd"` 
