### PR TITLE
Use the client passed or the Datadog::Statsd client.

### DIFF
--- a/lib/datadoge.rb
+++ b/lib/datadoge.rb
@@ -20,7 +20,7 @@ module Datadoge
         action = "action:#{event.payload[:action]}"
         format = "format:#{event.payload[:format] || 'all'}"
         format = "format:all" if format == "format:*/*"
-        host = "host:#{ENV['INSTRUMENTATION_HOSTNAME']}"
+        host = "host:#{ENV.fetch('INSTRUMENTATION_HOSTNAME', ENV['HOSTNAME'])}"
         status = event.payload[:status]
         tags = [controller, action, format, host]
         ActiveSupport::Notifications.instrument :performance, :action => :timing, :tags => tags, :measurement => "request.total_duration", :value => event.duration

--- a/lib/datadoge.rb
+++ b/lib/datadoge.rb
@@ -1,17 +1,18 @@
 require 'datadoge/version'
 require 'gem_config'
-require 'statsd'
+require 'datadog/statsd'
 
 module Datadoge
   include GemConfig::Base
 
   with_configuration do
     has :environments, classes: Array, default: ['production']
+    has :client, classes: Datadog::Statsd, default: nil
   end
 
   class Railtie < Rails::Railtie
     initializer "datadoge.configure_rails_initialization" do |app|
-      $statsd = Statsd.new
+      $statsd = Datadoge.configuration.client || Datadog::Statsd.new
 
       ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)

--- a/lib/datadoge.rb
+++ b/lib/datadoge.rb
@@ -8,6 +8,7 @@ module Datadoge
   with_configuration do
     has :environments, classes: Array, default: ['production']
     has :client, classes: Datadog::Statsd, default: nil
+    has :namespace, classes: String, default: 'rails'
   end
 
   class Railtie < Rails::Railtie
@@ -38,7 +39,7 @@ module Datadoge
         measurement = payload[:measurement]
         value = payload[:value]
         tags = payload[:tags]
-        key_name = "#{name.to_s.capitalize}.#{measurement}"
+        key_name = "#{Datadoge.configuration.namespace.to_s}.#{name.to_s.capitalize}.#{measurement}"
         if action == :increment
           $statsd.increment key_name, :tags => tags
         else


### PR DESCRIPTION
* Sets `host` tag to `ENV['HOSTNAME']` if `ENV['INSTRUMENTATION_HOSTNAME']` isn't set.
* Switches from `Statsd.new` to `Datadog::Statsd.new`.
* Allows you to pass a configured instance of `Datadog::Statsd` when configuring. This allows people to add tags, do namespaces, etc. 
* Add an _additional_ namespace that's added to `key`. This comes after any namespace configured in the client.